### PR TITLE
Updating email helper to use nodemailer and adding sample SMTP config…

### DIFF
--- a/server/configExample.js
+++ b/server/configExample.js
@@ -1,0 +1,17 @@
+//This file holds any configuration variables we may need 
+//'config.js' is ignored by git to protect sensitive information, such as your database's username and password
+//copy this file's contents to another file 'config.js' and store your MongoLab uri there
+
+module.exports = {
+    db: {
+        uri: '', //place the URI of your mongo database here.
+      },
+      port: 8080,
+  smtp: {
+    server: 'smtp.ethereal.email',
+    port: 587,
+    username: 'h7nfi5alh34v36jy@ethereal.email',
+    password: 'wAjgJazX1U3PtHB8HN',
+    useSSL: 0
+  }
+};

--- a/server/controllers/email.server.controller.js
+++ b/server/controllers/email.server.controller.js
@@ -10,23 +10,25 @@ exports.send = function(req, res) {
     var email = new Email(req.body);
 
     /* Send the email and update status appropriately */
-    if (emailHelper.send(req.body)) {
-        email.status = "Sent";
-        email.date_sent = new Date();
-    } else {
-        email.status = "Error";
-    }
-
-    email.project_id = req.params.projectId;
-
-    /* Then save the email */
-    email.save(function(err) {
-        if(err) {
-            console.log(err);
-            res.status(500).send(err);
+    emailHelper.send(req.body, function(success) {
+        if (success) {
+            email.status = "Sent";
+            email.date_sent = new Date();
         } else {
-            res.json(email);
+            email.status = "Error";
         }
+
+        email.project_id = req.params.projectId;
+
+        /* Then save the email */
+        email.save(function(err) {
+            if(err) {
+                console.log(err);
+                res.status(500).send(err);
+            } else {
+                res.json(email);
+            }
+        });
     });
 };
 

--- a/server/helpers/email.helper.js
+++ b/server/helpers/email.helper.js
@@ -1,45 +1,48 @@
 
 /* Dependencies */
-// var sendpulse = require("sendpulse-api");
-    // config = require('./config');
-
-// var TOKEN_STORAGE = "/tmp/";
+var nodemailer = require("nodemailer"),
+    config = require('../config');
 
 // Function used to abstract the calling code away from the implementation
 // of whatever API (or SMTP functionality) we are using
-module.exports.send = function(message) {
-
-    // TODO: Need to wire up the actual API we will be using
-    // var answerGetter = function(data) {
-    //     console.log(data);
-    // }
-
-    // sendpulse.init(API_USER_ID,API_SECRET,TOKEN_STORAGE);
-
-    // var email = {
-    //     "html" : "<h1>Example text</h1>",
-    //     "text" : "Example text",
-    //     "subject" : "Example subject",
-    //     "from" : {
-    //         "name" : "Alex",
-    //         "email" : "some@domain.com"
-    //     },
-    //     "to" : [
-    //         {
-    //             "name" : "Piter",
-    //             "email" : "8bxjcmuphk@liamekaens.com"
-    //         },
-    //     ],
-    //     "bcc" : [
-    //         {
-    //             "name" : "John",
-    //             "email" : "some@domain.info"
-    //         },
-    //     ]
-    // };
-
-    // sendpulse.smtpSendMail(answerGetter,email);
+module.exports.send = function(message, callback) {
 
     console.log(message);
-    return true;
+
+    // create reusable transporter object using the default SMTP transport
+    let transporter = nodemailer.createTransport({
+        host: config.smtp.server,
+        port: config.smtp.port,
+        secure: (config.smtp.useSSL === 1), // true for 465, false for other ports
+        auth: {
+            user: config.smtp.username,
+            pass: config.smtp.password
+        }
+    });
+    
+    // setup email data with unicode symbols
+    let mailOptions = {
+        from: message.sender,
+        to: message.recipient,
+        subject: message.subject,
+        text: message.body,
+        html: message.body
+    };
+
+    // send mail with defined transport object
+    transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+            console.log('Error sending message:');
+            console.log(error);
+            callback(false);
+        } else {
+            console.log('Message sent:');
+            console.log(info);
+
+            // Preview only available when sending through an Ethereal account
+            console.log('Preview URL: %s', nodemailer.getTestMessageUrl(info));
+    
+            callback(true);    
+        }
+    });
 };


### PR DESCRIPTION
… based on Ethereal.email to configExample.js

This pull request contains code to wire up the email helper to an external SMTP server using nodemailer.  This can be tested by adding the relevant SMTP settings to config.js (seen here in configExample.js).  The sample shown in configExample.js uses Ethereal, a "fake" SMTP service that responds just like real SMTP but does not actually deliver email.  I have tested this code with Ethereal and with a real SMTP server using my own personal email account.